### PR TITLE
Load blade color on Sound Font menu

### DIFF
--- a/Buttons.cpp
+++ b/Buttons.cpp
@@ -102,6 +102,9 @@ void ConfigMenuButtonEventHandler(bool SaturateColor, ButtonActionEnum ButtonAct
       confParseValue(storage.soundFont, 0, SOUNDFONT_QUANTITY - 1, 1*incrementSign);
       storage.soundFont = value;
       soundFont.setID(value);
+      getColor(storage.sndProfile[storage.soundFont].mainColor);
+        lightOn(ledPins, -1, currentColor);
+        delay(500);
       SinglePlay_Sound(soundFont.getMenu((storage.soundFont)*NR_FILE_SF));
       //Serial.print("soundfont   "); Serial.print(storage.soundFont); Serial.print("  Offset:   ");Serial.println(soundFont.getMenu((storage.soundFont)*NR_FILE_SF));
       delay(150);    

--- a/ConfigMenu.cpp
+++ b/ConfigMenu.cpp
@@ -122,6 +122,9 @@ void NextConfigState(){
         lightOff();
         SinglePlay_Sound(5);
         delay(600);
+	getColor(storage.sndProfile[storage.soundFont].mainColor);
+        lightOn(ledPins, -1, currentColor);
+        delay(500);
         SinglePlay_Sound(soundFont.getMenu((storage.soundFont)*NR_FILE_SF));
         delay(500);  
         break;


### PR DESCRIPTION
Add a call to load the blade color profile associated to the current Sound Font when entering Config/Sound Font menu